### PR TITLE
Add timeout decorator to RMSD calculations to prevent occasional process deadlocks

### DIFF
--- a/posebusters/modules/rmsd.py
+++ b/posebusters/modules/rmsd.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+import timeout_decorator
 from copy import deepcopy
 
 import numpy as np

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 requires-python = "~=3.8"
 dynamic = ["version", "description"]
-dependencies = ['rdkit >= 2020.09', 'pandas', 'numpy', 'pyyaml']
+dependencies = ['rdkit >= 2020.09', 'pandas', 'numpy', 'pyyaml', 'timeout_decorator']
 
 [project.optional-dependencies]
 dev = ["ruff"]


### PR DESCRIPTION
* Adds a timeout decorator to the `_rmsd` function to prevent occasional process deadlocks.
* The timeout is set to 30 seconds by default.