### PR TITLE
non-flatness check

### DIFF
--- a/posebusters/modules/flatness.py
+++ b/posebusters/modules/flatness.py
@@ -17,6 +17,14 @@ _flat = {
     "aromatic_6_membered_rings_sp2": "[ar6^2]1[ar6^2][ar6^2][ar6^2][ar6^2][ar6^2]1",
     "trigonal_planar_double_bonds": "[C;X3;^2](*)(*)=[C;X3;^2](*)(*)",
 }
+nonflat = {
+    "nonaromatic_5_membered_rings": "[C,O,S,N&!a]~1[C,O,S,N&!a][C,O,S,N&!a][C,O,S,N&!a][C,O,S,N&!a]1",
+    "nonaromatic_6_membered_rings": "[C,O,S,N&!a]~1[C,O,S,N&!a][C,O,S,N&!a][C,O,S,N&!a][C,O,S,N&!a][C,O,S,N&!a]1",
+    "nonaromatic_6_membered_rings_db03_0": "[C&!a]~1[C&!a][C,O,S,N&!a]~[C,O,S,N&!a][C&!a][C&!a]1",
+    "nonaromatic_6_membered_rings_db03_1": "[C&!a]~1[C&!a][C&!a]~[C&!a][C,O,S,N&!a][C&!a]1",
+    "nonaromatic_6_membered_rings_db02_0": "[C&!a]~1[C&!a][C&!a][C,O,S,N&!a]~[C,O,S,N&!a][C&!a]1",
+    "nonaromatic_6_membered_rings_db02_1": "[C&!a]~1[C&!a][C,O,S,N&!a][C&!a]~[C&!a][C&!a]1",
+}
 _empty_results = {
     "results": {
         "num_systems_checked": np.nan,
@@ -28,15 +36,20 @@ _empty_results = {
 
 
 def check_flatness(
-    mol_pred: Mol, threshold_flatness: float = 0.1, flat_systems: dict[str, str] = _flat
+    mol_pred: Mol,
+    threshold_flatness: float = 0.1,
+    flat_systems: dict[str, str] = _flat,
+    check_nonflat: bool = False,
 ) -> dict[str, Any]:
     """Check whether substructures of molecule are flat.
 
     Args:
         mol_pred: Molecule with exactly one conformer.
         threshold_flatness: Maximum distance from shared plane used as cutoff. Defaults to 0.1.
-        flat_systems: Patterns of flat systems provided as SMARTS. Defaults to 5 and 6 membered
-            aromatic rings and carbon sigma bonds.
+        flat_systems: Patterns of flat (or non-flat) systems provided as SMARTS. Defaults to
+             5 and 6 membered aromatic rings and carbon sigma bonds.
+        check_nonflat: Whether to check the ring non-flatness instead of flatness.
+            Turns (flatness <= threshold_flatness) to (flatness >= threshold_flatness).
 
     Returns:
         PoseBusters results dictionary.
@@ -60,8 +73,11 @@ def check_flatness(
     # calculate distances to plane and check threshold
     coords = [_get_coords(mol, group) for group in planar_groups]
     max_distances = [float(_get_distances_to_plane(X).max()) for X in coords]
-    flatness_passes = [bool(d <= threshold_flatness) for d in max_distances]
-
+    # operator for the flatness check
+    if not check_nonflat:
+        flatness_passes = [bool(d <= threshold_flatness) for d in max_distances]
+    else:
+        flatness_passes = [bool(d >= threshold_flatness) for d in max_distances]
     details = {
         "type": types,
         "planar_group": planar_groups,
@@ -75,6 +91,7 @@ def check_flatness(
         "max_distance": max(max_distances) if max_distances else np.nan,
         "flatness_passes": all(flatness_passes) if len(flatness_passes) > 0 else True,
     }
+    # print(flatness_passes, max_distances, results["flatness_passes"])
 
     return {"results": results, "details": details}
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import pytest
+from rdkit import Chem
+from rdkit.Chem import AllChem
+from rdkit.Chem.rdDistGeom import EmbedMolecule
 from rdkit.Chem.rdmolfiles import (
     MolFromMol2File,
     MolFromMolFile,
@@ -260,3 +263,35 @@ def mol_3wrb_gde_true():
 @pytest.fixture
 def mol_3wrb_gde_pred():
     return MolFromMolFile("tests/conftest/mol_3WRB_1_GDE_0_ligand_pred.sdf")
+
+
+@pytest.fixture()
+def mol_pip_ideal():
+    return MolFromMolFile("tests/conftest/PIP/PIP_ideal.sdf")
+
+
+@pytest.fixture()
+def mol_pip_pred():
+    return MolFromMolFile("tests/conftest/PIP/PIP_wrong.sdf")
+
+
+def embed_mol(smi: str) -> Chem.Mol:
+    hmol = Chem.AddHs(Chem.MolFromSmiles(smi))
+    ps = AllChem.srETKDGv3()
+    ps.randomState = 42
+    _ = EmbedMolecule(hmol, params=ps)
+    return hmol
+
+
+@pytest.fixture()
+def mols_flat_etkdgv3():
+    # non-aromatic flat
+    smis_flat = ["C1=CC2=CC=CC2=C1", "C1=C[CH]C=C1", "N1C=CNC=C1", "C1C=CN=CN1"]
+    return [embed_mol(smi) for smi in smis_flat]
+
+
+@pytest.fixture()
+def mols_nonflat_etkdgv3():
+    # just nonflat
+    smis_flat = ["C1CC(C)NC1", "N1C=CCC=C1", "C1C=CCCO1"]
+    return [embed_mol(smi) for smi in smis_flat]

--- a/tests/test_modules/test_flatness.py
+++ b/tests/test_modules/test_flatness.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from posebusters.modules.flatness import check_flatness
+from posebusters.modules.flatness import check_flatness, nonflat
 
 rings = {
     "aromatic_5_membered_rings_sp2": "[ar5^2]1[ar5^2][ar5^2][ar5^2][ar5^2]1",
@@ -41,3 +41,35 @@ def test_check_flatness_7ecr_sin(mol_lig_7ecr_sin):
     # pass because no rings or double bonds present
     out = check_flatness(mol_lig_7ecr_sin)
     assert out["results"]["flatness_passes"] is True
+
+
+def test_check_nonflatness_synthetic(mols_flat_etkdgv3, mols_nonflat_etkdgv3):
+    for mol in mols_flat_etkdgv3:
+        # these are flat and should be ignored by the patterns
+        out = check_flatness(mol, flat_systems=nonflat, check_nonflat=True)
+        assert out["results"]["flatness_passes"]
+
+    for mol in mols_nonflat_etkdgv3:
+        # these should be non-flat
+        out = check_flatness(mol, flat_systems=nonflat, check_nonflat=True)
+        assert out["results"]["flatness_passes"]
+
+
+def test_check_nonflatness_pip_ideal(mol_pip_ideal):
+    # ignored
+    out = check_flatness(mol_pip_ideal)
+    assert out["results"]["flatness_passes"] is True
+
+    # correct geometry
+    out = check_flatness(mol_pip_ideal, flat_systems=nonflat, check_nonflat=True)
+    assert out["results"]["flatness_passes"] is True
+
+
+def test_check_nonflatness_pip_pred(mol_pip_pred):
+    # ignored
+    out = check_flatness(mol_pip_pred)
+    assert out["results"]["flatness_passes"] is True
+
+    # flat geometry
+    out = check_flatness(mol_pip_pred, flat_systems=nonflat, check_nonflat=True)
+    assert out["results"]["flatness_passes"] is False


### PR DESCRIPTION
Addresses this issue https://github.com/maabuu/posebusters/issues/53

Adds a non-flatness checks for non-flat 5- and 6-membered rings with the following SMARTS patterns
```
    "nonaromatic_5_membered_rings": "[C,O,S,N&!a]~1[C,O,S,N&!a][C,O,S,N&!a][C,O,S,N&!a][C,O,S,N&!a]1",
    "nonaromatic_6_membered_rings": "[C,O,S,N&!a]~1[C,O,S,N&!a][C,O,S,N&!a][C,O,S,N&!a][C,O,S,N&!a][C,O,S,N&!a]1",
    "nonaromatic_6_membered_rings_db03_0": "[C&!a]~1[C&!a][C,O,S,N&!a]~[C,O,S,N&!a][C&!a][C&!a]1",
    "nonaromatic_6_membered_rings_db03_1": "[C&!a]~1[C&!a][C&!a]~[C&!a][C,O,S,N&!a][C&!a]1",
    "nonaromatic_6_membered_rings_db02_0": "[C&!a]~1[C&!a][C&!a][C,O,S,N&!a]~[C,O,S,N&!a][C&!a]1",
    "nonaromatic_6_membered_rings_db02_1": "[C&!a]~1[C&!a][C,O,S,N&!a][C&!a]~[C&!a][C&!a]1",
```