### PR TITLE
Expose `num_threads` parameter

### DIFF
--- a/posebusters/modules/energy_ratio.py
+++ b/posebusters/modules/energy_ratio.py
@@ -48,6 +48,7 @@ def check_energy_ratio(
             average. Defaults to 100.
         inchi_strict: Whether to treat warnings in the InChI generation as errors. Defaults to False.
         num_threads: The number of threads to use for energy minimization.
+            By default, the number of available cores is used.
 
     Returns:
         PoseBusters results dictionary.

--- a/posebusters/modules/energy_ratio.py
+++ b/posebusters/modules/energy_ratio.py
@@ -37,6 +37,7 @@ def check_energy_ratio(
     ensemble_number_conformations: int = 100,
     inchi_strict: bool = False,
     epsilon=1e-10,
+    num_threads=0,
 ) -> dict[str, dict[str, float | bool]]:
     """Check whether the energy of the docked ligand is within user defined range.
 
@@ -46,6 +47,7 @@ def check_energy_ratio(
         ensemble_number_conformations: Number of conformations to generate for the ensemble over which to
             average. Defaults to 100.
         inchi_strict: Whether to treat warnings in the InChI generation as errors. Defaults to False.
+        num_threads: The number of threads to use for energy minimization.
 
     Returns:
         PoseBusters results dictionary.
@@ -76,7 +78,7 @@ def check_energy_ratio(
         observed_energy = float("nan")
 
     try:
-        energies = get_energies(inchi, ensemble_number_conformations)
+        energies = get_energies(inchi, ensemble_number_conformations, num_threads)
         mean_energy = sum(energies) / len(energies)
         std_energy = sum((energy - mean_energy) ** 2 for energy in energies) / (len(energies) - 1)
         std_energy = max(epsilon, std_energy)  # clipping

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,9 @@ docstring-code-format = true
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["D", "PLR2004"]
 
+[tool.ruff.lint.pylint]
+max-args = 6
+
 [tool.mypy]
 ignore_missing_imports = true
 


### PR DESCRIPTION
Exposing the `num_threads` parameter would allow the user to control the number of threads that are used by `posebusters`