### PR TITLE
Make package PEP561 compliant

### DIFF
--- a/posebusters/cli.py
+++ b/posebusters/cli.py
@@ -20,7 +20,7 @@ from .tools.formatting import create_long_output, create_short_output
 logger = logging.getLogger(__name__)
 
 
-def main():
+def main() -> None:
     """Safe entry point for PoseBusters from the command line."""
     parser = _parse_args(sys.argv[1:])
     try:
@@ -42,7 +42,7 @@ def bust(  # noqa: PLR0913
     top_n: int | None = None,
     max_workers: bool = False,
     chunk_size: int | None = None,
-):
+) -> None:
     """PoseBusters: Plausibility checks for generated molecule poses."""
     if table is None and len(mol_pred) == 0:
         raise ValueError("Provide either MOLS_PRED or TABLE.")
@@ -71,7 +71,7 @@ def bust(  # noqa: PLR0913
         output.write(_format_results(results, outfmt, no_header, i))
 
 
-def _parse_args(args):
+def _parse_args(args: list[str]) -> argparse.Namespace:
     desc = "PoseBusters: Plausibility checks for generated molecule poses."
     parser = argparse.ArgumentParser(description=desc, add_help=False)
 
@@ -145,8 +145,8 @@ def _format_results(df: pd.DataFrame, outfmt: str = "short", no_header: bool = F
     raise ValueError(f"Unknown output format {outfmt}")
 
 
-def _select_mode(config, columns: Iterable[str]) -> str | dict[str, Any]:
-    # decide on mode to run
+def _select_mode(config: Path | None, columns: Iterable[str]) -> str | dict[str, Any]:
+    """Decide which mode to run on based on the inputs."""
 
     # load config if provided
     if isinstance(config, Path):
@@ -169,7 +169,7 @@ def _select_mode(config, columns: Iterable[str]) -> str | dict[str, Any]:
     return mode
 
 
-def _path(path_str: str):
+def _path(path_str: str | Path) -> Path:
     path = Path(path_str)
     if not path.exists():
         raise argparse.ArgumentTypeError(f"File {path} not found!")

--- a/posebusters/datasets/load_datasets.py
+++ b/posebusters/datasets/load_datasets.py
@@ -7,26 +7,26 @@ import pandas as pd
 dataset_dir = Path(__file__).parent
 
 
-def _prepend_path(file_path):
+def _prepend_path(file_path: Path | str) -> Path:
     return dataset_dir / file_path
 
 
-def _load_dataset(cols):
+def _load_dataset(cols: list[str]) -> pd.DataFrame:
     files = pd.read_csv(dataset_dir / "pdb.csv")
     files[cols] = files[cols].apply(_prepend_path)
     return files[["name"] + cols]
 
 
-def four_redocks():
+def four_redocks() -> pd.DataFrame:
     """Load the four docks dataset."""
     return _load_dataset(["mol_pred", "mol_true", "mol_cond"])
 
 
-def four_docks():
+def four_docks() -> pd.DataFrame:
     """Load the four docks dataset."""
     return _load_dataset(["mol_pred", "mol_cond"])
 
 
-def four_mols():
+def four_mols() -> pd.DataFrame:
     """Load the four mols dataset."""
     return _load_dataset(["mol_pred"])

--- a/posebusters/modules/distance_geometry.py
+++ b/posebusters/modules/distance_geometry.py
@@ -82,10 +82,10 @@ def symmetrize_conjugated_terminal_bonds(df: pd.DataFrame, mol: Mol) -> pd.DataF
         for conjugated terminal bonds are symmetrized.
     """
 
-    def _sort_bond_ids(bond_ids: tuple[tuple | list]):
+    def _sort_bond_ids(bond_ids: tuple[tuple | list]) -> tuple[tuple, ...]:
         return tuple(tuple(sorted(_)) for _ in bond_ids)
 
-    def _get_terminal_group_matches(_mol: Mol):
+    def _get_terminal_group_matches(_mol: Mol) -> tuple[tuple, ...]:
         qsmarts = "[O,N;D1;$([O,N;D1]-[*]=[O,N;D1]),$([O,N;D1]=[*]-[O,N;D1])]~[*]"
         qsmarts = MolFromSmarts(qsmarts)
         matches = _mol.GetSubstructMatches(qsmarts)
@@ -263,7 +263,7 @@ def _clash_check(df: pd.DataFrame) -> pd.DataFrame:
     # clash is only when lower bound is violated
     df = df[(~df["is_bond"]) & (~df["is_angle"])].copy()
 
-    def _lb_pe(value, lower_bound):
+    def _lb_pe(value: float, lower_bound: float) -> float:
         if value >= lower_bound:
             return 0.0
         return pe(value, lower_bound)
@@ -310,7 +310,7 @@ def _sort_bond(bond: tuple[int, int]) -> tuple[int, int]:
     return (min(bond), max(bond))
 
 
-def _pairwise_distance(x):
+def _pairwise_distance(x: np.ndarray) -> np.ndarray:
     return np.linalg.norm(x[:, None, :] - x[None, :, :], axis=-1)
 
 

--- a/posebusters/modules/rmsd.py
+++ b/posebusters/modules/rmsd.py
@@ -164,7 +164,7 @@ def _rmsd_ignoring_charges_and_tautomers(
     return rmsd
 
 
-def _call_rdkit_rmsd(mol_probe: Mol, mol_ref: Mol, conf_id_probe: int, conf_id_ref: int, **params):
+def _call_rdkit_rmsd(mol_probe: Mol, mol_ref: Mol, conf_id_probe: int, conf_id_ref: int, **params) -> float:
     try:
         with CaptureLogger():
             return _rmsd(mol_probe, mol_ref, conf_id_probe, conf_id_ref, **params)
@@ -176,7 +176,7 @@ def _call_rdkit_rmsd(mol_probe: Mol, mol_ref: Mol, conf_id_probe: int, conf_id_r
     return np.nan
 
 
-def _rmsd(mol_probe: Mol, mol_ref: Mol, conf_id_probe: int, conf_id_ref: int, kabsch: bool = False, **params):
+def _rmsd(mol_probe: Mol, mol_ref: Mol, conf_id_probe: int, conf_id_ref: int, kabsch: bool = False, **params) -> float:
     if kabsch is True:
         return GetBestRMS(prbMol=mol_probe, refMol=mol_ref, prbId=conf_id_probe, refId=conf_id_ref, **params)
     return CalcRMS(prbMol=mol_probe, refMol=mol_ref, prbId=conf_id_probe, refId=conf_id_ref, **params)

--- a/posebusters/modules/sanity.py
+++ b/posebusters/modules/sanity.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from copy import deepcopy
+from typing import Any
 
 import pandas as pd
 from rdkit import RDLogger
@@ -13,7 +14,7 @@ from rdkit.Chem.rdmolops import DetectChemistryProblems, GetMolFrags, SanitizeFl
 from ..tools.inchi import get_inchi
 
 
-def check_chemistry_using_rdkit(mol_pred: Mol):
+def check_chemistry_using_rdkit(mol_pred: Mol) -> dict[str, Any]:
     """Check sanity of molecule using RDKit sanitization rules."""
     assert isinstance(mol_pred, Mol)
     mol = deepcopy(mol_pred)
@@ -36,7 +37,7 @@ def check_chemistry_using_rdkit(mol_pred: Mol):
     return {"results": results, "details": details}
 
 
-def check_chemistry_using_inchi(mol_pred: Mol):
+def check_chemistry_using_inchi(mol_pred: Mol) -> dict[str, Any]:
     """Check sanity of a molecule using InChI rules."""
     assert isinstance(mol_pred, Mol)
     mol = deepcopy(mol_pred)
@@ -57,7 +58,7 @@ def check_chemistry_using_inchi(mol_pred: Mol):
     return {"results": {"inchi_convertible": passes}, "details": dict(errors=errors, inchi=inchi)}
 
 
-def check_all_atoms_connected(mol_pred: Mol):
+def check_all_atoms_connected(mol_pred: Mol) -> dict[str, Any]:
     """Check if all atoms in a molecule are connected."""
     assert isinstance(mol_pred, Mol)
     mol = deepcopy(mol_pred)
@@ -69,7 +70,7 @@ def check_all_atoms_connected(mol_pred: Mol):
     return {"results": results, "details": details}
 
 
-def check_chemistry(mol_pred: Mol):
+def check_chemistry(mol_pred: Mol) -> dict[str, Any]:
     """Check sanity using RDKit and connectedness.
 
     Notes:

--- a/posebusters/posebusters.py
+++ b/posebusters/posebusters.py
@@ -283,13 +283,13 @@ class PoseBusters:
             self.module_args.append(module_args)
 
     @staticmethod
-    def _get_name(mol: Mol) -> str:
+    def _get_name(mol: Mol | None) -> str:
         """Get the name of a molecule from the RDKit molecule object. Returns empty string if no name found."""
         if mol is None or not mol.HasProp("_Name"):
             return ""
         return mol.GetProp("_Name")
 
-    def _collect_in_table(self, results_gen, full_report) -> pd.DataFrame:
+    def _collect_in_table(self, results_gen: Generator, full_report: bool) -> pd.DataFrame:
         """Collect generator results in a pandas dataframe."""
 
         df = pd.concat([self._make_table({k: v}, self.config, full_report=full_report) for k, v in results_gen])
@@ -299,7 +299,7 @@ class PoseBusters:
         return df
 
     @staticmethod
-    def _make_table(results_dict: ResultDict, config, full_report: bool = False) -> pd.DataFrame:
+    def _make_table(results_dict: ResultDict, config: dict[str, Any], full_report: bool = False) -> pd.DataFrame:
         """Generate a table from the output of the tests."""
 
         d = {id: {(module, output): value for module, output, value in results} for id, results in results_dict.items()}

--- a/posebusters/tools/loading.py
+++ b/posebusters/tools/loading.py
@@ -158,6 +158,7 @@ def _load_and_combine_mols(path: Path, sanitize=True, removeHs=True, strictParsi
             if mol_next is not None:
                 mol.AddConformer(mol_next.GetConformer(), assignId=True)
         return mol
+    return None
 
 
 def _process_mol(  # noqa: PLR0913

--- a/posebusters/tools/molecules.py
+++ b/posebusters/tools/molecules.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
 from copy import deepcopy
 from logging import getLogger
 
@@ -115,7 +114,7 @@ def get_hbond_donors(mol: Mol) -> set[int]:
     return {s[0] for s in mol.GetSubstructMatches(HDonorSmarts, uniquify=1)}
 
 
-def delete_atoms(mol: Mol, indices: Iterable[int]) -> Mol:
+def delete_atoms(mol: Mol, indices: list[int]) -> Mol:
     """Delete atoms from molecule.
 
     Args:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,12 +23,12 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Operating System :: OS Independent",
 ]
-requires-python = "~=3.9"
+requires-python = ">=3.9"
 dynamic = ["version", "description"]
 dependencies = ['rdkit >= 2024.9', 'pandas', 'numpy', 'pyyaml']
 
 [project.optional-dependencies]
-dev = ["ruff"]
+dev = ["ruff", "mypy"]
 docs = [
     "ipython",
     "nbsphinx",


### PR DESCRIPTION
Make package PEP 561 compliant
- Add marker file `py.typed` to signal that package includes PEP 561-compliant type hints.
- Add missing in-line type hints